### PR TITLE
Fix an uncaught error / Add retry button

### DIFF
--- a/src/reason/Form.re
+++ b/src/reason/Form.re
@@ -43,7 +43,7 @@ let make = (~onChange) => {
 
   let prevQuestion = () => {
     setState(s => s.questionIndex == 0 ? s : { questionIndex: s.questionIndex-1 });
-    onChange(~answer=Some(0.0));
+    onChange(~answer=None);
   };
 
   let progress = Js.Int.toFloat(state.questionIndex) /. Js.Int.toFloat(Questions.length) *. 100.0;

--- a/src/reason/Form.re
+++ b/src/reason/Form.re
@@ -40,10 +40,10 @@ let make = (~onChange) => {
     setState(s => s.questionIndex == Array.length(questions)-1 ? s : { questionIndex: s.questionIndex+1 });
     onChange(~answer=Some(questionScore));
   };
-  
+
   let prevQuestion = () => {
     setState(s => s.questionIndex == 0 ? s : { questionIndex: s.questionIndex-1 });
-    onChange(~answer=None);
+    onChange(~answer=Some(0.0));
   };
 
   let progress = Js.Int.toFloat(state.questionIndex) /. Js.Int.toFloat(Questions.length) *. 100.0;

--- a/src/reason/Quiz.re
+++ b/src/reason/Quiz.re
@@ -14,8 +14,9 @@ let make = () => {
 
   let onChange = (~answer: option(float)) => {
     let newAnswers = switch answer {
-    | Some(value) => [value, ...state.answers]
-    | None        => List.tl(state.answers)
+    | Some(value)                   => [value, ...state.answers]
+    | None when state.answers != [] => List.tl(state.answers)
+    | _                             => []
     };
     setState(_ => { answers: newAnswers });
   };

--- a/src/reason/Results.re
+++ b/src/reason/Results.re
@@ -2,11 +2,12 @@ open MaterialUi;
 
 [@react.component]
 let make = (~score) => {
-  
+
   let rank = Ranks.getRank(score);
 
   let rankStyle = ReactDOMRe.Style.make(~marginTop="200px", ());
   let descriptionStyle = ReactDOMRe.Style.make(~marginTop="20px", ());
+  let buttonStyle = ReactDOMRe.Style.make(~marginTop="50px", ());
 
   <Container>
     <Typography variant=`H2 align=`Center style=rankStyle>
@@ -15,5 +16,10 @@ let make = (~score) => {
     <Typography variant=`H5 align=`Center style=descriptionStyle>
       {Ranks.getDescription(rank)}
     </Typography>
+    <Box textAlign=Box.Value.string("center")>
+      <Button variant=`Contained onClick=(_ => ReasonReact.Router.push("/")) style=buttonStyle>
+        "Recommencer"
+      </Button>
+    </Box>
   </Container>
 };


### PR DESCRIPTION
When trying to get back to the previous question from the first one, an uncaught error is displayed
in the console because the onChange send a `None` which is not accepted. Changed to `Some(0.0)` solve the issue.

STR:
- Click on `Question précédente`
- See console.

```
index.e6e56be7b0c8212e7ab1.js:22 Uncaught {RE_EXN_ID: "Failure", _1: "tl", Error: Error
    at https://darons.io/index.e6e56be7b0c8212e7ab1.js:45:82087
    at onChange (https://daro…}Error: Error
    at https://darons.io/index.e6e56be7b0c8212e7ab1.js:45:82087
    at onChange (https://darons.io/index.e6e56be7b0c8212e7ab1.js:45:82098)
    at Fi (https://darons.io/index.e6e56be7b0c8212e7ab1.js:45:57975)
    at onClick (https://darons.io/index.e6e56be7b0c8212e7ab1.js:45:79571)
    at Object.l (https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:455)
    at p (https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:598)
    at https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:744
    at y (https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:830)
    at at (https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:16358)
    at it (https://darons.io/index.e6e56be7b0c8212e7ab1.js:22:16168)RE_EXN_ID: "Failure"_1: "tl"__proto__: Object
lt @ index.e6e56be7b0c8212e7ab1.js:22
pt @ index.e6e56be7b0c8212e7ab1.js:22
L @ index.e6e56be7b0c8212e7ab1.js:22
W @ index.e6e56be7b0c8212e7ab1.js:22
Jt @ index.e6e56be7b0c8212e7ab1.js:22
Gt @ index.e6e56be7b0c8212e7ab1.js:22
t.unstable_runWithPriority @ index.e6e56be7b0c8212e7ab1.js:30
Vi @ index.e6e56be7b0c8212e7ab1.js:22
A @ index.e6e56be7b0c8212e7ab1.js:22
Xt @ index.e6e56be7b0c8212e7ab1.js:22
```